### PR TITLE
Added support for passing Cargo.toml file path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,10 @@ struct Options {
     )]
     /// Set the target branch
     branch: String,
+
+    #[structopt(short = "t", long = "cargo-toml")]
+    /// Pass the path of the `Cargo.toml` file
+    cargo_toml: Option<String>,
 }
 
 fn display_warnings(warnings: &[clippy::Lint]) {
@@ -48,7 +52,10 @@ fn main() -> Result<(), error::Error> {
         .set_verbose(opts.verbose)
         .get_sections(&opts.branch)?;
     println!("Checking Cargo manifest");
-    let manifest = cargo::Parser::from_manifest_path("./Cargo.toml")?;
+    let path = opts
+        .cargo_toml
+        .unwrap_or_else(|| String::from("./Cargo.toml"));
+    let manifest = cargo::Parser::from_manifest_path(path)?;
     if manifest.is_workspace() {
         println!("Running in workspace, please note feature flags are not supported yet.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,9 @@ struct Options {
     /// Set the target branch
     branch: String,
 
-    #[structopt(short = "t", long = "cargo-toml")]
+    #[structopt(short = "t", long = "cargo-toml", default_value = "./Cargo.toml")]
     /// Pass the path of the `Cargo.toml` file
-    cargo_toml: Option<String>,
+    cargo_toml: String,
 }
 
 fn display_warnings(warnings: &[clippy::Lint]) {
@@ -52,10 +52,7 @@ fn main() -> Result<(), error::Error> {
         .set_verbose(opts.verbose)
         .get_sections(&opts.branch)?;
     println!("Checking Cargo manifest");
-    let path = opts
-        .cargo_toml
-        .unwrap_or_else(|| String::from("./Cargo.toml"));
-    let manifest = cargo::Parser::from_manifest_path(path)?;
+    let manifest = cargo::Parser::from_manifest_path(opts.cargo_toml)?;
     if manifest.is_workspace() {
         println!("Running in workspace, please note feature flags are not supported yet.");
     }


### PR DESCRIPTION
Regarding issue #31. I am not sure if additional tests are needed since errors are handled by `cargo_toml` crate and forwarded to `cargo_scout`, but I can add them if needed.