### PR TITLE
Use Into<PathBuf> to improve Linter usability

### DIFF
--- a/cargo-scout-lib/src/linter/clippy.rs
+++ b/cargo-scout-lib/src/linter/clippy.rs
@@ -51,7 +51,11 @@ struct Span {
 }
 
 impl linter::Linter for Clippy {
-    fn lints(&self, working_dir: PathBuf) -> Result<Vec<linter::Lint>, crate::error::Error> {
+    fn lints(
+        &self,
+        working_dir: impl Into<PathBuf>,
+    ) -> Result<Vec<linter::Lint>, crate::error::Error> {
+        let working_dir = working_dir.into();
         println!(
             "[Clippy] - getting lints for directory {}",
             &working_dir.to_str().unwrap_or("<no directory>")

--- a/cargo-scout-lib/src/linter/mod.rs
+++ b/cargo-scout-lib/src/linter/mod.rs
@@ -4,7 +4,7 @@ pub mod clippy;
 pub mod rustfmt;
 
 pub trait Linter {
-    fn lints(&self, working_dir: PathBuf) -> Result<Vec<Lint>, crate::error::Error>;
+    fn lints(&self, working_dir: impl Into<PathBuf>) -> Result<Vec<Lint>, crate::error::Error>;
 }
 
 /// This struct contains the lint,

--- a/cargo-scout-lib/src/linter/rustfmt.rs
+++ b/cargo-scout-lib/src/linter/rustfmt.rs
@@ -10,7 +10,8 @@ use std::process::Command;
 pub struct RustFmt {}
 
 impl Linter for RustFmt {
-    fn lints(&self, working_dir: PathBuf) -> Result<Vec<Lint>, Error> {
+    fn lints(&self, working_dir: impl Into<PathBuf>) -> Result<Vec<Lint>, Error> {
+        let working_dir = working_dir.into();
         println!(
             "[RustFmt] - checking format for directory {}",
             &working_dir.to_str().unwrap_or("<no directory>")

--- a/cargo-scout-lib/src/scout/mod.rs
+++ b/cargo-scout-lib/src/scout/mod.rs
@@ -136,7 +136,10 @@ mod scout_tests {
         }
     }
     impl Linter for TestLinter {
-        fn lints(&self, _working_dir: PathBuf) -> Result<Vec<Lint>, crate::error::Error> {
+        fn lints(
+            &self,
+            _working_dir: impl Into<PathBuf>,
+        ) -> Result<Vec<Lint>, crate::error::Error> {
             *self.lints_times_called.borrow_mut() += 1;
             Ok(self.lints.clone())
         }


### PR DESCRIPTION
It seems that we don't need to work with associated types in this case. I guess it's because the type parameter is on the method and not on the trait itself?

Closes #75 