### PR TITLE
Fix command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,10 @@ before_script:
     fi
 script:
   - cargo fmt -- --check
-  - cargo test --all
-  - cargo clippy --all-targets --tests -- -D clippy::pedantic
-after_success: |
+  - |
     if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-      USE_SKEPTIC=1 cargo tarpaulin --out Xml
-      bash <(curl -s https://codecov.io/bash)
-      echo "Uploaded code coverage"
+      USE_SKEPTIC=1 cargo tarpaulin --out Xml && bash <(curl -s https://codecov.io/bash) && echo "Uploaded code coverage"
+    else
+      cargo test --all
     fi
+  - cargo clippy --all-targets --tests -- -D clippy::pedantic

--- a/cargo-scout-lib/src/error.rs
+++ b/cargo-scout-lib/src/error.rs
@@ -18,4 +18,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("Git error: {0}")]
     Git(#[from] git2::Error),
+    #[error("The provided command is invalid.")]
+    InvalidCommand,
+    #[error("Couldn't strip prefix from path: {0}")]
+    StripPrefix(#[from] std::path::StripPrefixError),
 }

--- a/cargo-scout-lib/src/healer/mod.rs
+++ b/cargo-scout-lib/src/healer/mod.rs
@@ -1,0 +1,5 @@
+use crate::linter::Lint;
+
+pub trait Healer {
+    fn heal(&self, lints: Vec<Lint>) -> Result<(), crate::error::Error>;
+}

--- a/cargo-scout-lib/src/lib.rs
+++ b/cargo-scout-lib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod error;
+pub mod healer;
 pub mod linter;
 pub mod scout;
 pub mod vcs;

--- a/cargo-scout-lib/src/linter/mod.rs
+++ b/cargo-scout-lib/src/linter/mod.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::path::PathBuf;
 
 pub mod clippy;
@@ -21,7 +22,7 @@ pub struct Lint {
 }
 
 /// A `Location` has a file name, a start and an end line
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Serialize, PartialEq, Clone, Debug)]
 pub struct Location {
     pub path: String,
     pub lines: [u32; 2],

--- a/cargo-scout-lib/src/scout/mod.rs
+++ b/cargo-scout-lib/src/scout/mod.rs
@@ -1,9 +1,10 @@
 use crate::config::*;
+use crate::healer::Healer;
 use crate::linter::{Lint, Linter};
 use crate::vcs::*;
 use std::path::PathBuf;
 
-pub struct Scout<V, C, L>
+pub struct Scout<'s, V, C, L>
 where
     V: VCS,
     C: Config,
@@ -11,16 +12,16 @@ where
 {
     vcs: V,
     config: C,
-    linter: L,
+    linter: &'s L,
 }
 
-impl<V, C, L> Scout<V, C, L>
+impl<'s, V, C, L> Scout<'s, V, C, L>
 where
     V: VCS,
     C: Config,
     L: Linter,
 {
-    pub fn new(vcs: V, config: C, linter: L) -> Self {
+    pub fn new(vcs: V, config: C, linter: &'s L) -> Self {
         Self {
             vcs,
             config,
@@ -44,6 +45,26 @@ where
         }
         println!("[Scout] - checking for intersections");
         Ok(lints_from_diff(&lints, &diff_sections))
+    }
+}
+
+pub struct Fixer<H>
+where
+    H: Healer,
+{
+    medic: H,
+}
+
+impl<H> Fixer<H>
+where
+    H: Healer,
+{
+    pub fn new(medic: H) -> Self {
+        Self { medic }
+    }
+    pub fn run(&self, lints: Vec<Lint>) -> Result<(), crate::error::Error> {
+        println!("[Scout] - applying fixes");
+        self.medic.heal(lints)
     }
 }
 
@@ -94,7 +115,6 @@ mod scout_tests {
     use std::cell::RefCell;
     use std::clone::Clone;
     use std::path::{Path, PathBuf};
-    use std::rc::Rc;
     struct TestVCS {
         sections: Vec<Section>,
         sections_called: RefCell<bool>,
@@ -117,20 +137,20 @@ mod scout_tests {
         // Using a RefCell here because lints
         // takes &self and not &mut self.
         // We use usize here because we will compare it to a Vec::len()
-        lints_times_called: Rc<RefCell<usize>>,
+        times_called: RefCell<usize>,
         lints: Vec<Lint>,
     }
     impl TestLinter {
         pub fn new() -> Self {
             Self {
-                lints_times_called: Rc::new(RefCell::new(0)),
+                times_called: RefCell::new(0),
                 lints: Vec::new(),
             }
         }
 
         pub fn with_lints(lints: Vec<Lint>) -> Self {
             Self {
-                lints_times_called: Rc::new(RefCell::new(0)),
+                times_called: RefCell::new(0),
                 lints,
             }
         }
@@ -140,8 +160,14 @@ mod scout_tests {
             &self,
             _working_dir: impl Into<PathBuf>,
         ) -> Result<Vec<Lint>, crate::error::Error> {
-            *self.lints_times_called.borrow_mut() += 1;
+            *self.times_called.borrow_mut() += 1;
             Ok(self.lints.clone())
+        }
+    }
+    impl Healer for TestLinter {
+        fn heal(&self, _lints: Vec<Lint>) -> Result<(), crate::error::Error> {
+            *self.times_called.borrow_mut() += 1;
+            Ok(())
         }
     }
     struct TestConfig {
@@ -165,13 +191,12 @@ mod scout_tests {
         // No members so we won't have to iterate
         let config = TestConfig::new(Vec::new());
         let expected_times_called = 0;
-        let actual_times_called = Rc::clone(&linter.lints_times_called);
-        let scout = Scout::new(vcs, config, linter);
+        let scout = Scout::new(vcs, config, &linter);
         // We don't check for the lints result here.
         // It is already tested in the linter tests
         // and in intersection tests
         let _ = scout.run()?;
-        assert_eq!(expected_times_called, *actual_times_called.borrow());
+        assert_eq!(expected_times_called, *linter.times_called.borrow());
         Ok(())
     }
 
@@ -213,13 +238,12 @@ mod scout_tests {
         // The member matches the file name
         let config = TestConfig::new(vec!["foo".to_string()]);
         let expected_times_called = 1;
-        let actual_times_called = Rc::clone(&linter.lints_times_called);
-        let scout = Scout::new(vcs, config, linter);
+        let scout = Scout::new(vcs, config, &linter);
         // We don't check for the lints result here.
         // It is already tested in the linter tests
         // and in intersection tests
         let actual_lints_from_diff = scout.run()?;
-        assert_eq!(expected_times_called, *actual_times_called.borrow());
+        assert_eq!(expected_times_called, *linter.times_called.borrow());
         assert_eq!(expected_lints_from_diff, actual_lints_from_diff);
         Ok(())
     }
@@ -236,13 +260,12 @@ mod scout_tests {
         // The member does not match the file name
         let config = TestConfig::new(vec!["foo".to_string()]);
         let expected_times_called = 0;
-        let actual_times_called = Rc::clone(&linter.lints_times_called);
-        let scout = Scout::new(vcs, config, linter);
+        let scout = Scout::new(vcs, config, &linter);
         // We don't check for the lints result here.
         // It is already tested in the linter tests
         // and in intersection tests
         let _ = scout.run()?;
-        assert_eq!(expected_times_called, *actual_times_called.borrow());
+        assert_eq!(expected_times_called, *linter.times_called.borrow());
         Ok(())
     }
 
@@ -270,14 +293,27 @@ mod scout_tests {
         ]);
         // We should run the linter on member1 and member2
         let expected_times_called = 2;
-        let actual_times_called = Rc::clone(&linter.lints_times_called);
-        let scout = Scout::new(vcs, config, linter);
+        let scout = Scout::new(vcs, config, &linter);
         // We don't check for the lints result here.
         // It is already tested in the linter tests
         // and in intersection tests
         let _ = scout.run()?;
 
-        assert_eq!(expected_times_called, *actual_times_called.borrow());
+        assert_eq!(expected_times_called, *linter.times_called.borrow());
+        Ok(())
+    }
+
+    #[test]
+    fn test_heal() -> Result<(), crate::error::Error> {
+        let fixer = TestLinter::new();
+        let config = TestConfig::new(Vec::new());
+        let vcs = TestVCS::new(Vec::new());
+
+        let expected_times_called = 1;
+        let scout = Scout::new(vcs, config, &fixer);
+        let lints = scout.run()?;
+        fixer.heal(lints)?;
+        assert_eq!(expected_times_called, *fixer.times_called.borrow());
         Ok(())
     }
 }

--- a/cargo-scout-lib/src/utils.rs
+++ b/cargo-scout-lib/src/utils.rs
@@ -6,3 +6,25 @@ pub fn get_absolute_file_path(file_path: impl AsRef<Path>) -> Result<String, Err
     absolute_path.push(file_path);
     Ok(absolute_path.to_string_lossy().to_string())
 }
+
+pub fn get_relative_file_path(file_path: impl AsRef<Path>) -> Result<String, Error> {
+    let current_dir = std::env::current_dir()?;
+    let relative_path = file_path
+        .as_ref()
+        .strip_prefix(current_dir.to_string_lossy().to_string())?;
+    Ok(relative_path.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_file_path_conversion() -> Result<(), crate::error::Error> {
+        let relative_path = "foo/bar.rs";
+        assert_eq!(
+            relative_path,
+            get_relative_file_path(get_absolute_file_path(relative_path)?)?
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
This will allow us to to fix the formatting issues by running: 

`cargo-scout fix fmt`

Although it won't apply to clippy(yet?), it will allow us to close #72 